### PR TITLE
Set rook to a particular version

### DIFF
--- a/ansible/rook/files/cluster.yaml
+++ b/ansible/rook/files/cluster.yaml
@@ -161,7 +161,7 @@ spec:
     # v12 is luminous, v13 is mimic, and v14 is nautilus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v13 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    image: ceph/ceph:v13
+    image: ceph/ceph:v13.2.4-20190109
     # Whether to allow unsupported versions of Ceph. Currently only luminous and mimic are supported.
     # After nautilus is released, Rook will be updated to support nautilus.
     # Do not set to true in production.

--- a/ansible/rook/files/operator.yaml
+++ b/ansible/rook/files/operator.yaml
@@ -405,7 +405,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:master
+        image: rook/ceph:v0.9.3
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook


### PR DESCRIPTION
and ensure the YAML files are as per the set version.

Prevents YAML deviance when using master from Rook.

Signed-off-by: ShyamsundarR <srangana@redhat.com>