### PR TITLE
Up k8s version to latest 1.13 release

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -3,4 +3,4 @@
 feature_gates:
   - "CustomResourceSubresources=true"
 k8s_init_token: "000000.1111111111111111"
-k8s_version: 1.13.0
+k8s_version: 1.13.5


### PR DESCRIPTION
This prevents a slew of install time dependency errors when
using CentOS7 as the base image in vagrant.

Signed-off-by: ShyamsundarR <srangana@redhat.com>