### PR TITLE
Fix playbook warning

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -44,14 +44,14 @@
 - name: Enable net bridge iptables
   sysctl:
     name: net.bridge.bridge-nf-call-iptables
-    value: 1
+    value: "1"
     state: present
     reload: true
 
 - name: Enable net bridge ip6tables
   sysctl:
     name: net.bridge.bridge-nf-call-ip6tables
-    value: 1
+    value: "1"
     state: present
     reload: true
 


### PR DESCRIPTION
Log:
TASK [common : Enable net bridge iptables] ******************************
Friday 06 March 2020  12:57:30 +0530 (0:00:05.386)       0:07:05.297 ****
[WARNING]: The value 1 (type int) in a string field was converted to u'1'
(type string). If this does not look like what you expect, quote the
entire value to ensure it does not change.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>