### PR TITLE
ssh: enable PasswordAuthentication in sshd_config

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -10,6 +10,12 @@
     state: latest
   register: upgrade
 
+- name: Enable PasswordAuthentication in sshd_config
+  lineinfile:
+    name: /etc/ssh/sshd_config
+    regexp: "^PasswordAuthentication no"
+    line: "PasswordAuthentication yes"
+
 - name: Reboot if packages were upgraded
   shell: sleep 2 && systemctl reboot
   async: 1


### PR DESCRIPTION
Post intallation, this enables user:
- use scp for copy files to required destination directories both
  from host node to vms' and in between all the vm's
- easy ssh from any dir of host-node (we don't have to be in
  k8s-cluster repo everytime)

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>