### PR TITLE
vagrant: disable QEMU session support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,8 @@ Vagrant.configure("2") do |config|
     lv.volume_cache = "writeback"
     lv.video_type = "vga"
     lv.video_vram = "1024"
+    # Always use system connection instead of QEMU session
+    lv.qemu_use_session = false
   end
 
   # Can't write to /vagrant on atomic-host, so disable default sync dir


### PR DESCRIPTION
vagrant-libvirt supports using QEMU user sessions to maintain Vagrant
VMs, and some distros turn it ON by default.

After upgrading to Fedora32 I have noticed `vagrant up` fails with a huge call
trace and disabling QEMU session worked.

More read:
https://github.com/vagrant-libvirt/vagrant-libvirt#qemu-session-support
https://fedoraproject.org/wiki/Changes/Vagrant_2.2_with_QEMU_Session

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>